### PR TITLE
bug fix on select span inside input

### DIFF
--- a/select/select.js
+++ b/select/select.js
@@ -52,7 +52,8 @@ export class Select {
   clickHandler(event) {
     const {type} = event.target.dataset
 
-    if (type === 'input') {
+    if (type === 'input' || event.target.closest('.select__input')) {
+      // клик может прийтись не только по input, но и по содежащемуся внутри него span
       this.toggle()
     } else if (type === 'item') {
       const id = event.target.dataset.id


### PR DESCRIPTION
Исправлен баг, который приводил к тому, что событие клика не срабатывало как ожидалось, если клик пришелся не непосредственно по input, а по содержащемуся внутри него span или другому элементу. 
Теперь, при клике, проверяется, есть ли в родителях кликнутого элемента нужный input. 
Если есть, значит клик пришелся по дочернему элементу нужного input. 
Следовательно, пользователь желает открыть выпадающий список.